### PR TITLE
Node 16 deprecated, use Node 20 actions

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -15,14 +15,14 @@ jobs:
           image: davesnowdon/alpha2build:sha-94523ae
         steps:
         - name: Checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
 
         - name: Build SDK
           shell: bash
           run: ./gradlew assembleRelease
 
         - name: Archive SDK
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
               name: alpha2opensdk.aar
               path: ubtechalpha2robot/build/outputs/aar/ubtechalpha2robot-release.aar


### PR DESCRIPTION
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/